### PR TITLE
Response's array also contains values in CDATA

### DIFF
--- a/lib/Namecheap/Api/Response.php
+++ b/lib/Namecheap/Api/Response.php
@@ -119,15 +119,14 @@ class Response
             if ($item instanceof \SimpleXMLElement) {
 
                 if (count((array) $item) > 0) {
-
                     $array[$key] = $this->xmlToArray($item);
+                } elseif ((string) $item) {
+                    $array[$key] = (string) $item;
                 } else {
-
                     $array[$key] = null;
                 }
 
             } elseif (is_array($item)) {
-
 
                 $array[$key] = $this->xmlToArray($item);
             }


### PR DESCRIPTION
Method before the change returned NULL instead of text inside CDATA marks. With this change also CDATA is contained in the array. This is useful for getting SSL certificates in the getInfo API method.
